### PR TITLE
ログイン画面の文言を修正

### DIFF
--- a/MobileNovelReader/LoginDisplay/LoginDisplayView.swift
+++ b/MobileNovelReader/LoginDisplay/LoginDisplayView.swift
@@ -22,15 +22,15 @@ struct LoginDisplayView: View {
                     .font(.title)
                     .padding(.bottom, 80)
 
-                createTextField(iconName: "person", field: TextField("ID", text: $id)
+                createTextField(iconName: "person", field: TextField("Eメール", text: $id)
                     .keyboardType(.alphabet))
 
                 if isPasswordVisible {
-                    createTextField(iconName: "lock", field: TextField("Password", text: $password)
+                    createTextField(iconName: "lock", field: TextField("パスワード", text: $password)
                         .keyboardType(.alphabet))
                         .overlay(passwordVisibilityToggle)
                 } else {
-                    createTextField(iconName: "lock", field: SecureField("Password", text: $password)
+                    createTextField(iconName: "lock", field: SecureField("パスワード", text: $password)
                         .keyboardType(.alphabet))
                         .overlay(passwordVisibilityToggle)
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ログイン画面のプレースホルダーテキストを英語から日本語に更新しました。「ID」を「Eメール」に、「Password」を「パスワード」に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->